### PR TITLE
Catch SecurityException on PDF renderer instantiation

### DIFF
--- a/pdfviewer/src/main/java/com/danjdt/pdfviewer/PdfViewer.kt
+++ b/pdfviewer/src/main/java/com/danjdt/pdfviewer/PdfViewer.kt
@@ -39,10 +39,11 @@ class PdfViewer private constructor(
     private fun display(file: File) {
         try {
             setup(file)
-        } catch (e: IOException) {
-            errorListener?.onPdfRendererError(e)
         } catch (e: Exception) {
-            errorListener?.onAttachViewError(e)
+            when (e) {
+                is IOException, is SecurityException -> errorListener?.onPdfRendererError(e)
+                else -> errorListener?.onAttachViewError(e)
+            }
         }
     }
 

--- a/pdfviewer/src/main/java/com/danjdt/pdfviewer/interfaces/OnErrorListener.kt
+++ b/pdfviewer/src/main/java/com/danjdt/pdfviewer/interfaces/OnErrorListener.kt
@@ -1,6 +1,5 @@
 package com.danjdt.pdfviewer.interfaces
 
-import java.io.IOException
 import java.lang.Exception
 
 interface OnErrorListener {
@@ -9,5 +8,5 @@ interface OnErrorListener {
 
     fun onAttachViewError(e : Exception)
 
-    fun onPdfRendererError(e : IOException)
+    fun onPdfRendererError(e : Exception)
 }

--- a/pdfviewer/src/main/java/com/danjdt/pdfviewer/renderer/PdfPageRenderer.kt
+++ b/pdfviewer/src/main/java/com/danjdt/pdfviewer/renderer/PdfPageRenderer.kt
@@ -15,16 +15,14 @@ import kotlinx.coroutines.withContext
 import java.io.File
 
 class PdfPageRenderer(
-    private val file: File,
+    file: File,
     private val quality: PdfPageQuality,
     private val dispatcher: CoroutineDispatcher,
 ) {
     private val deferredMap = mutableMapOf<Int, Deferred<Result<Bitmap>>>()
     private val mutex = Mutex()
 
-    private val pdfRenderer: PdfRenderer by lazy {
-        openRenderer(file)
-    }
+    private val pdfRenderer = openRenderer(file)
 
     val pageCount: Int by lazy {
         pdfRenderer.pageCount

--- a/pdfviewer/src/main/java/com/danjdt/pdfviewer/view/adapter/PdfPagesAdapter.kt
+++ b/pdfviewer/src/main/java/com/danjdt/pdfviewer/view/adapter/PdfPagesAdapter.kt
@@ -9,14 +9,12 @@ import kotlinx.coroutines.CoroutineDispatcher
 import java.io.File
 
 abstract class PdfPagesAdapter<T : PdfPageViewHolder>(
-    private val pdfFile: File,
-    private val quality: PdfPageQuality,
-    private val dispatcher: CoroutineDispatcher,
+    pdfFile: File,
+    quality: PdfPageQuality,
+    dispatcher: CoroutineDispatcher,
 ) : ListAdapter<Bitmap, T>(DiffCallback()) {
 
-    private val pdfPageRenderer: PdfPageRenderer by lazy {
-        PdfPageRenderer(pdfFile, quality, dispatcher)
-    }
+    private val pdfPageRenderer = PdfPageRenderer(pdfFile, quality, dispatcher)
 
     suspend fun renderPage(position: Int): Result<Bitmap> {
         return pdfPageRenderer.render(position)

--- a/sample/src/main/java/androidpdfviewer/com/danjdt/sample/SampleActivity.kt
+++ b/sample/src/main/java/androidpdfviewer/com/danjdt/sample/SampleActivity.kt
@@ -13,7 +13,6 @@ import com.danjdt.pdfviewer.interfaces.OnErrorListener
 import com.danjdt.pdfviewer.interfaces.OnPageChangedListener
 import com.danjdt.pdfviewer.utils.PdfPageQuality
 import kotlinx.coroutines.Dispatchers
-import java.io.IOException
 
 
 class SampleActivity : AppCompatActivity(), OnPageChangedListener , OnErrorListener {
@@ -86,7 +85,7 @@ class SampleActivity : AppCompatActivity(), OnPageChangedListener , OnErrorListe
         e.printStackTrace()
     }
 
-    override fun onPdfRendererError(e: IOException) {
+    override fun onPdfRendererError(e: Exception) {
         //Handle error ...
         e.printStackTrace()
     }


### PR DESCRIPTION
The PR addresses crash when opening a password-protected PDF file.

SecurityException is thrown on PdfRenderer instantiation when the file is password-protected. See https://developer.android.com/reference/android/graphics/pdf/PdfRenderer#PdfRenderer(android.os.ParcelFileDescriptor)