### PR TITLE
 Fix missing pages in PDF viewer caused by unreliable layout sizing

### DIFF
--- a/pdfviewer/src/main/java/com/danjdt/pdfviewer/view/adapter/DefaultPdfPageViewHolder.kt
+++ b/pdfviewer/src/main/java/com/danjdt/pdfviewer/view/adapter/DefaultPdfPageViewHolder.kt
@@ -2,7 +2,9 @@ package com.danjdt.pdfviewer.view.adapter
 
 import android.graphics.Bitmap
 import android.view.View
+import android.view.ViewGroup
 import android.widget.ImageView
+import androidx.core.view.updateLayoutParams
 import com.danjdt.pdfviewer.R
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -24,7 +26,9 @@ class DefaultPdfPageViewHolder(
             val renderResult = renderBlock(position)
             ensureActive()
             renderResult.onSuccess { page ->
-                imageView.layoutParams.height =  (page.height.toDouble() * imageView.width / page.width).toInt()
+                imageView.updateLayoutParams {
+                    height = ViewGroup.LayoutParams.WRAP_CONTENT
+                }
                 imageView.setImageBitmap(page)
             }
         }

--- a/pdfviewer/src/main/res/layout/pdf_page.xml
+++ b/pdfviewer/src/main/res/layout/pdf_page.xml
@@ -3,4 +3,5 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/image"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    android:adjustViewBounds="true" />


### PR DESCRIPTION
 ## Problem                                             
                                                                                                                            
`DefaultPdfPageViewHolder` occasionally rendered blank/missing pages. Two issues contributed:

-  When `bind()` ran before the ImageView had been measured, `imageView.width` was `0`, producing a height of `0` — the page was  present in the adapter but invisible on screen.
- The page height was computed manually as `page.height * imageView.width / page.width` and assigned via `imageView.layoutParams.height = …`. Mutating `layoutParams` in place does **not** call `requestLayout()`, so the new height was not always picked up on the next layout pass.

## Fix                                                                                                                    
                                                         
- `pdf_page.xml`: add `android:adjustViewBounds="true"` so the ImageView  preserves the bitmap's aspect ratio against the `match_parent` width.
- `DefaultPdfPageViewHolder.kt`: replace the manual height calculation with `imageView.updateLayoutParams { height = WRAP_CONTENT }`. The KTX helper reassigns `layoutParams`, which correctly triggers `requestLayout()`. Combined with `adjustViewBounds`, the framework now computes the same aspect-ratio-preserving height it was computed before - but reliably, and without depending on`imageView.width` being measured at bind time.                                                                          

## Why `layout_height="match_parent"` is kept in XML                                                                      
   
The XML value is the **initial** height of an item before its render coroutine completes. It must remain non-zero, because RecyclerView decides how many items to bind based on how many fit in the viewport: if freshly-created items measured to 0 px tall, RecyclerView would conclude that the entire dataset fits on screen and bind every page at once. That would kick off a render coroutine for every page in the document simultaneously - defeating recycling, spiking memory, and stalling the                                                 UI.

Keeping `match_parent` ensures each not-yet-rendered cell occupies the full viewport, so RecyclerView only binds the page(s) actually visible. Once `updateLayoutParams { height = WRAP_CONTENT }` runs and `adjustViewBounds` resizes the ImageView to the bitmap, the cell collapses to its correct height and the next page is bound — exactly as before this fix. 

## Behavior                                            
                                                                                                                            
End-state layout is mathematically equivalent to the previous code (`adjustViewBounds` performs the same `height = bitmapHeight * width / bitmapWidth` calculation internally).